### PR TITLE
Support stimuli filepaths

### DIFF
--- a/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
+++ b/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
@@ -17,6 +17,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
+import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
 import org.apache.commons.io.IOUtils;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
@@ -74,7 +75,12 @@ public class S3ItemDataRepository implements ItemDataRepository {
         final String dirName = file.getParentFile() == null
             ? ""
             : file.getParentFile().getName();
+        // If the directory name is not present, default to "items"
+        final String itemsOrStimuli = StringUtils.isEmpty(dirName)
+            ? "items"
+            : file.getParentFile().getParentFile().getName();
 
-        return normalize("items/" + dirName + "/" + file.getName());
+
+        return normalize(itemsOrStimuli + "/" + dirName + "/" + file.getName());
     }
 }

--- a/src/test/java/tds/content/repositories/impl/S3ItemDataRepositoryTest.java
+++ b/src/test/java/tds/content/repositories/impl/S3ItemDataRepositoryTest.java
@@ -90,6 +90,23 @@ public class S3ItemDataRepositoryTest {
         assertThat(request.getKey()).isEqualTo(scoringS3Properties.getItemPrefix() + "items/My-Item/My-Item.xml");
     }
 
+    @Test
+    public void itShouldTrimLongUrisStimuli() throws Exception {
+        final String longPath = "/usr/local/tomcat/resources/tds/bank/stimuli/My-Stim/My-Stim.xml";
+
+        final S3Object response = mock(S3Object.class);
+        when(response.getObjectContent()).thenReturn(response("Response Data"));
+
+        when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenReturn(response);
+
+        final String value = itemReader.findOne(longPath);
+        final ArgumentCaptor<GetObjectRequest> objectRequestArgumentCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
+        verify(mockAmazonS3).getObject(objectRequestArgumentCaptor.capture());
+
+        final GetObjectRequest request = objectRequestArgumentCaptor.getValue();
+        assertThat(request.getKey()).isEqualTo(scoringS3Properties.getItemPrefix() + "stimuli/My-Stim/My-Stim.xml");
+    }
+
     private S3ObjectInputStream response(final String body) throws Exception {
         final ByteArrayInputStream delegate = new ByteArrayInputStream(body.getBytes(UTF_8));
         return new S3ObjectInputStream(delegate, mock(HttpRequestBase.class));


### PR DESCRIPTION
Previously we were hardcoding the "items" string into the filepath - this can alternatively be a request for stimuli content.

Note: We may eventually decide to move this function out into a separate, common class, which may be utilize by other services/apps that request item, passage content or other resources.