### PR TITLE
Returning 403/AccessDeniedException when S3 returns a 403

### DIFF
--- a/src/main/java/tds/content/controllers/ContentController.java
+++ b/src/main/java/tds/content/controllers/ContentController.java
@@ -76,7 +76,6 @@ public class ContentController {
 
         return ResponseEntity.ok()
             .headers(headers)
-//            .contentLength(resource.contentLength())
             .body(resource);
     }
 }

--- a/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
+++ b/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
@@ -21,6 +21,7 @@ import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.springframework.context.annotation.Primary;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Repository;
 
 import java.io.File;
@@ -72,9 +73,11 @@ public class S3ItemDataRepository implements ItemDataRepository {
             return item.getObjectContent();
         } catch (final AmazonS3Exception ex) {
             if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-                throw new NotFoundException(String.format("Could not find resource at resource location %s", resourcePath));
+                throw new NotFoundException(String.format("Could not find resource at resource location %s", resourceLocation));
+            } else if (ex.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+                throw new AccessDeniedException(String.format("Could not access the resource at resource location %s", resourceLocation));
             }
-            throw new IOException("Unable to read S3 item: " + resourceLocation, ex);
+            throw ex;
         }
     }
 

--- a/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
+++ b/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
@@ -20,6 +20,8 @@ import com.amazonaws.services.s3.model.S3Object;
 import net.logstash.logback.encoder.org.apache.commons.lang.StringUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Repository;
@@ -27,7 +29,6 @@ import org.springframework.stereotype.Repository;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Optional;
 
 import tds.common.web.exceptions.NotFoundException;
 import tds.content.configuration.S3Properties;
@@ -39,6 +40,7 @@ import static org.apache.commons.io.FilenameUtils.normalize;
 @Repository
 @Primary
 public class S3ItemDataRepository implements ItemDataRepository {
+    private final Logger log = LoggerFactory.getLogger(S3ItemDataRepository.class);
     private final AmazonS3 s3Client;
     private final S3Properties s3Properties;
 
@@ -73,8 +75,10 @@ public class S3ItemDataRepository implements ItemDataRepository {
             return item.getObjectContent();
         } catch (final AmazonS3Exception ex) {
             if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+                log.warn("AmazonS3Exception thrown with a status of \"Not Found\" for path {}.", resourceLocation);
                 throw new NotFoundException(String.format("Could not find resource at resource location %s", resourceLocation));
             } else if (ex.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+                log.warn("AmazonS3Exception thrown with a status of \"Forbidden\" for path {}.", resourceLocation);
                 throw new AccessDeniedException(String.format("Could not access the resource at resource location %s", resourceLocation));
             }
             throw ex;

--- a/src/test/java/tds/content/repositories/impl/S3ItemDataRepositoryTest.java
+++ b/src/test/java/tds/content/repositories/impl/S3ItemDataRepositoryTest.java
@@ -158,10 +158,12 @@ public class S3ItemDataRepositoryTest {
         itemReader.findResource(resourcePath);
     }
 
-    @Test(expected = IOException.class)
-    public void shouldThrowIOException() throws Exception {
+    @Test(expected = NotFoundException.class)
+    public void shouldThrowNotFoundException() throws Exception {
         final String resourcePath = "items/my-Item/My-resource.xml";
-        when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenThrow(AmazonS3Exception.class);
+        AmazonS3Exception exception = new AmazonS3Exception("Exception");
+        exception.setStatusCode(HttpStatus.SC_NOT_FOUND);
+        when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenThrow(exception);
         itemReader.findResource(resourcePath);
     }
 }

--- a/src/test/java/tds/content/repositories/impl/S3ItemDataRepositoryTest.java
+++ b/src/test/java/tds/content/repositories/impl/S3ItemDataRepositoryTest.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.security.access.AccessDeniedException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -145,6 +147,15 @@ public class S3ItemDataRepositoryTest {
         when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenReturn(response);
         InputStream retData = itemReader.findResource(resourcePath);
         assertThat(IOUtils.toString(retData)).isEqualTo("Response Data");
+    }
+
+    @Test(expected = AccessDeniedException.class)
+    public void shouldThrowAccessDenidFor403() throws Exception {
+        final String resourcePath = "items/my-Item/My-resource.xml";
+        AmazonS3Exception exception = new AmazonS3Exception("Exception");
+        exception.setStatusCode(HttpStatus.SC_FORBIDDEN);
+        when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenThrow(exception);
+        itemReader.findResource(resourcePath);
     }
 
     @Test(expected = IOException.class)


### PR DESCRIPTION
Depending on user permissions, sometimes S3 will return a 403 instead of a 404 when an item is not found and the user does not have permissions to list the directory. Previously this was resulting in ContentService returning a 500.