### PR TITLE
Fixing content controller status codes, removing unused imports

### DIFF
--- a/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
+++ b/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
@@ -23,14 +23,12 @@ import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Repository;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import tds.common.web.exceptions.NotFoundException;
 import tds.content.configuration.S3Properties;
 import tds.content.repositories.ItemDataRepository;
 
@@ -76,10 +74,10 @@ public class S3ItemDataRepository implements ItemDataRepository {
         } catch (final AmazonS3Exception ex) {
             if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
                 log.warn("AmazonS3Exception thrown with a status of \"Not Found\" for path {}.", resourceLocation);
-                throw new NotFoundException(String.format("Could not find resource at resource location %s", resourceLocation));
+                throw ex;
             } else if (ex.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
                 log.warn("AmazonS3Exception thrown with a status of \"Forbidden\" for path {}.", resourceLocation);
-                throw new AccessDeniedException(String.format("Could not access the resource at resource location %s", resourceLocation));
+                throw ex;
             }
             throw ex;
         }

--- a/src/test/java/tds/content/repositories/impl/S3ItemDataRepositoryTest.java
+++ b/src/test/java/tds/content/repositories/impl/S3ItemDataRepositoryTest.java
@@ -14,12 +14,10 @@
 package tds.content.repositories.impl;
 
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,13 +25,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.springframework.security.access.AccessDeniedException;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
-import tds.common.web.exceptions.NotFoundException;
 import tds.content.configuration.S3Properties;
 
 import static com.google.common.base.Charsets.UTF_8;
@@ -106,7 +101,6 @@ public class S3ItemDataRepositoryTest {
 
         when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenReturn(response);
 
-        final String value = itemReader.findOne(longPath);
         final ArgumentCaptor<GetObjectRequest> objectRequestArgumentCaptor = ArgumentCaptor.forClass(GetObjectRequest.class);
         verify(mockAmazonS3).getObject(objectRequestArgumentCaptor.capture());
 
@@ -147,23 +141,5 @@ public class S3ItemDataRepositoryTest {
         when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenReturn(response);
         InputStream retData = itemReader.findResource(resourcePath);
         assertThat(IOUtils.toString(retData)).isEqualTo("Response Data");
-    }
-
-    @Test(expected = AccessDeniedException.class)
-    public void shouldThrowAccessDenidFor403() throws Exception {
-        final String resourcePath = "items/my-Item/My-resource.xml";
-        AmazonS3Exception exception = new AmazonS3Exception("Exception");
-        exception.setStatusCode(HttpStatus.SC_FORBIDDEN);
-        when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenThrow(exception);
-        itemReader.findResource(resourcePath);
-    }
-
-    @Test(expected = NotFoundException.class)
-    public void shouldThrowNotFoundException() throws Exception {
-        final String resourcePath = "items/my-Item/My-resource.xml";
-        AmazonS3Exception exception = new AmazonS3Exception("Exception");
-        exception.setStatusCode(HttpStatus.SC_NOT_FOUND);
-        when(mockAmazonS3.getObject(any(GetObjectRequest.class))).thenThrow(exception);
-        itemReader.findResource(resourcePath);
     }
 }


### PR DESCRIPTION
My previously fix apparently did not work as expected - Spring was not properly converting my "AccessDeniedException" to a 403.

Instead of checking the status code at the repository level and re-throwing a new exception, I am now handling all http-related matters at the Controller level. I've also added controller integration tests to assure that we are returning the correct status code.