### PR TITLE
Return 403/404 for missing scoring rubric

### DIFF
--- a/src/main/java/tds/content/controllers/ContentController.java
+++ b/src/main/java/tds/content/controllers/ContentController.java
@@ -111,6 +111,13 @@ public class ContentController {
             return ResponseEntity.ok(contentService.loadData(new URI(itemPath)));
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(String.format("The provided item path '%s' was malformed", itemPath));
+        } catch (final AmazonS3Exception ex) {
+            if (ex.getStatusCode() == org.apache.http.HttpStatus.SC_NOT_FOUND) {
+                return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+            } else if (ex.getStatusCode() == org.apache.http.HttpStatus.SC_FORBIDDEN) {
+                return new ResponseEntity<>(ex.getMessage(), HttpStatus.FORBIDDEN);
+            }
+            throw ex;
         }
     }
 }

--- a/src/main/java/tds/content/controllers/ContentController.java
+++ b/src/main/java/tds/content/controllers/ContentController.java
@@ -111,13 +111,8 @@ public class ContentController {
             return ResponseEntity.ok(contentService.loadData(new URI(itemPath)));
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(String.format("The provided item path '%s' was malformed", itemPath));
-        } catch (final AmazonS3Exception ex) {
-            if (ex.getStatusCode() == org.apache.http.HttpStatus.SC_NOT_FOUND) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
-            } else if (ex.getStatusCode() == org.apache.http.HttpStatus.SC_FORBIDDEN) {
-                return new ResponseEntity<>(ex.getMessage(), HttpStatus.FORBIDDEN);
-            }
-            throw ex;
+        } catch (final FileNotFoundException ex) {
+            return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
         }
     }
 }

--- a/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
+++ b/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
@@ -58,7 +58,14 @@ public class S3ItemDataRepository implements ItemDataRepository {
 
             return IOUtils.toString(item.getObjectContent(), UTF_8);
         } catch (final AmazonS3Exception ex) {
-            throw new IOException("Unable to read S3 item: " + itemLocation, ex);
+            if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+                log.warn("AmazonS3Exception thrown with a status of \"Not Found\" for path {}.", itemDataPath);
+                throw ex;
+            } else if (ex.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+                log.warn("AmazonS3Exception thrown with a status of \"Forbidden\" for path {}.", itemDataPath);
+                throw ex;
+            }
+            throw new IllegalArgumentException("Unable to read S3 item: " + itemDataPath);
         }
     }
 

--- a/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
+++ b/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Repository;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -58,12 +59,9 @@ public class S3ItemDataRepository implements ItemDataRepository {
 
             return IOUtils.toString(item.getObjectContent(), UTF_8);
         } catch (final AmazonS3Exception ex) {
-            if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+            if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND || ex.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
                 log.warn("AmazonS3Exception thrown with a status of \"Not Found\" for path {}.", itemDataPath);
-                throw ex;
-            } else if (ex.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
-                log.warn("AmazonS3Exception thrown with a status of \"Forbidden\" for path {}.", itemDataPath);
-                throw ex;
+                throw new FileNotFoundException(ex.getMessage());
             }
             throw new IllegalArgumentException("Unable to read S3 item: " + itemDataPath);
         }

--- a/src/test/java/tds/content/controllers/ContentControllerIntegrationTests.java
+++ b/src/test/java/tds/content/controllers/ContentControllerIntegrationTests.java
@@ -143,26 +143,11 @@ public class ContentControllerIntegrationTests {
     @Test
     public void shouldReturn404ForNoResourceFoundGetItemData() throws Exception {
         URI uri = new URI("/path/to/item.xml");
-        AmazonS3Exception notFoundException = new AmazonS3Exception("Not Found");
-        notFoundException.setStatusCode(HttpStatus.NOT_FOUND.value());
-        when(contentService.loadData(uri)).thenThrow(notFoundException);
+        when(contentService.loadData(uri)).thenThrow(FileNotFoundException.class);
         URI restUri = UriComponentsBuilder.fromUriString("/loadData").build().toUri();
 
         http.perform(get(restUri)
             .param("itemPath", uri.toString()))
             .andExpect(status().isNotFound());
-    }
-
-    @Test
-    public void shouldReturn403ForAccessDeniedGetItemData() throws Exception {
-        URI uri = new URI("/path/to/item.xml");
-        AmazonS3Exception acessDeniedException = new AmazonS3Exception("Access Denied");
-        acessDeniedException.setStatusCode(HttpStatus.FORBIDDEN.value());
-        when(contentService.loadData(uri)).thenThrow(acessDeniedException);
-        URI restUri = UriComponentsBuilder.fromUriString("/loadData").build().toUri();
-
-        http.perform(get(restUri)
-            .param("itemPath", uri.toString()))
-            .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/tds/content/controllers/ContentControllerIntegrationTests.java
+++ b/src/test/java/tds/content/controllers/ContentControllerIntegrationTests.java
@@ -139,4 +139,30 @@ public class ContentControllerIntegrationTests {
             .param("resourcePath", uri.toString()))
             .andExpect(status().isForbidden());
     }
+
+    @Test
+    public void shouldReturn404ForNoResourceFoundGetItemData() throws Exception {
+        URI uri = new URI("/path/to/item.xml");
+        AmazonS3Exception notFoundException = new AmazonS3Exception("Not Found");
+        notFoundException.setStatusCode(HttpStatus.NOT_FOUND.value());
+        when(contentService.loadData(uri)).thenThrow(notFoundException);
+        URI restUri = UriComponentsBuilder.fromUriString("/loadData").build().toUri();
+
+        http.perform(get(restUri)
+            .param("itemPath", uri.toString()))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void shouldReturn403ForAccessDeniedGetItemData() throws Exception {
+        URI uri = new URI("/path/to/item.xml");
+        AmazonS3Exception acessDeniedException = new AmazonS3Exception("Access Denied");
+        acessDeniedException.setStatusCode(HttpStatus.FORBIDDEN.value());
+        when(contentService.loadData(uri)).thenThrow(acessDeniedException);
+        URI restUri = UriComponentsBuilder.fromUriString("/loadData").build().toUri();
+
+        http.perform(get(restUri)
+            .param("itemPath", uri.toString()))
+            .andExpect(status().isForbidden());
+    }
 }


### PR DESCRIPTION
https://jira.fairwaytech.com/browse/TDS-1164

A missing rubric file defined in an item metadata XML was not found in S3. Rather than returning a 404 (or 403 depending on AWS permissions), the ContentService was incorrectly returning a 500 in this case.