### PR TITLE
Encoding/decoding URIs to support spaces in URI path

### DIFF
--- a/src/main/java/tds/content/configuration/web/ContentExceptionAdvice.java
+++ b/src/main/java/tds/content/configuration/web/ContentExceptionAdvice.java
@@ -31,7 +31,7 @@ import tds.common.web.resources.ExceptionMessageResource;
  * Adds ContentService specific handling by extending the Common exception handling
  */
 @ControllerAdvice
-public class ContentExceptionAdvice extends ExceptionAdvice{
+public class ContentExceptionAdvice extends ExceptionAdvice {
     private final static Logger LOG = LoggerFactory.getLogger(ContentExceptionAdvice.class);
 
     @ExceptionHandler(FileNotFoundException.class)

--- a/src/main/java/tds/content/configuration/web/ContentExceptionAdvice.java
+++ b/src/main/java/tds/content/configuration/web/ContentExceptionAdvice.java
@@ -1,0 +1,45 @@
+/***************************************************************************************************
+ * Copyright 2017 Regents of the University of California. Licensed under the Educational
+ * Community License, Version 2.0 (the “license”); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the license at
+ *
+ * https://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required under applicable law or agreed to in writing, software distributed under the
+ * License is distributed in an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for specific language governing permissions
+ * and limitations under the license.
+ **************************************************************************************************/
+
+package tds.content.configuration.web;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+import java.io.FileNotFoundException;
+
+import tds.common.web.advice.ExceptionAdvice;
+import tds.common.web.resources.ExceptionMessageResource;
+
+/**
+ * Adds ContentService specific handling by extending the Common exception handling
+ */
+@ControllerAdvice
+public class ContentExceptionAdvice extends ExceptionAdvice{
+    private final static Logger LOG = LoggerFactory.getLogger(ContentExceptionAdvice.class);
+
+    @ExceptionHandler(FileNotFoundException.class)
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    @ResponseBody
+    ResponseEntity<ExceptionMessageResource> handleValidationException(final FileNotFoundException ex) {
+        LOG.warn("FileNotFoundException Exception", ex);
+        return new ResponseEntity<>(
+            new ExceptionMessageResource(HttpStatus.NOT_FOUND.toString(), ex.getMessage()), HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/tds/content/repositories/impl/FileSystemItemDataRepository.java
+++ b/src/main/java/tds/content/repositories/impl/FileSystemItemDataRepository.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Repository;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLDecoder;
 
 import tds.content.repositories.ItemDataRepository;
 
@@ -30,18 +31,19 @@ import static org.apache.commons.io.Charsets.UTF_8;
 public class FileSystemItemDataRepository implements ItemDataRepository {
     @Override
     public String findOne(final String itemPath) throws IOException {
-        return Files.toString(new File(itemPath), UTF_8);
+        File itemFile = new File(URLDecoder.decode(itemPath, org.apache.commons.lang3.CharEncoding.UTF_8));
+        return Files.toString(itemFile, UTF_8);
     }
 
     @Override
     public InputStream findResource(final String resourcePath) throws IOException {
-        File resourceFile = new File(resourcePath);
+        File resourceFile = new File(URLDecoder.decode(resourcePath, org.apache.commons.lang3.CharEncoding.UTF_8));
         return Files.asByteSource(resourceFile).openStream();
     }
 
     @Override
     public boolean doesItemExists(final String itemPath) throws IOException {
-        File itemFile = new File(itemPath);
+        File itemFile = new File(URLDecoder.decode(itemPath, org.apache.commons.lang3.CharEncoding.UTF_8));
         return itemFile.isFile();
     }
 }

--- a/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
+++ b/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLDecoder;
 
 import tds.content.configuration.S3Properties;
 import tds.content.repositories.ItemDataRepository;
@@ -104,7 +105,7 @@ public class S3ItemDataRepository implements ItemDataRepository {
      * @return The resource path relative to our S3 bucket and prefix
      */
     private String buildPath(final String itemDataPath) {
-        final File file = new File(normalize(itemDataPath));
+        final File file = new File(normalize(URLDecoder.decode(itemDataPath)));
         final String dirName = file.getParentFile() == null
             ? ""
             : file.getParentFile().getName();

--- a/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
+++ b/src/main/java/tds/content/repositories/impl/S3ItemDataRepository.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 
+import tds.common.web.exceptions.NotFoundException;
 import tds.content.configuration.S3Properties;
 import tds.content.repositories.ItemDataRepository;
 
@@ -62,7 +63,7 @@ public class S3ItemDataRepository implements ItemDataRepository {
         } catch (final AmazonS3Exception ex) {
             if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND || ex.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
                 log.warn("AmazonS3Exception thrown with a status of \"Not Found\" for path {}.", itemDataPath);
-                throw new FileNotFoundException(ex.getMessage());
+                throw new NotFoundException(ex.getMessage());
             }
             throw new IllegalArgumentException("Unable to read S3 item: " + itemDataPath);
         }
@@ -78,12 +79,9 @@ public class S3ItemDataRepository implements ItemDataRepository {
 
             return item.getObjectContent();
         } catch (final AmazonS3Exception ex) {
-            if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
-                log.warn("AmazonS3Exception thrown with a status of \"Not Found\" for path {}.", resourceLocation);
-                throw ex;
-            } else if (ex.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
-                log.warn("AmazonS3Exception thrown with a status of \"Forbidden\" for path {}.", resourceLocation);
-                throw ex;
+            if (ex.getStatusCode() == HttpStatus.SC_NOT_FOUND || ex.getStatusCode() == HttpStatus.SC_FORBIDDEN) {
+                log.warn("AmazonS3Exception thrown with a status of \"Not Found\" for path {}.", resourcePath);
+                throw new NotFoundException(ex.getMessage());
             }
             throw ex;
         }


### PR DESCRIPTION
Support for spaces in filenames

https://jira.fairwaytech.com/browse/TDS-1166

The URI class does not support spaces in the filepath, so these spaces must be encoded. S3, however does not expect file paths to be URL encoded and expects a literal space (' ') in the filename (as opposed to say a "+" or "%20"). 